### PR TITLE
Add implementations for PDoubleArrayOutput

### DIFF
--- a/src/apache_commons_matrix/core.clj
+++ b/src/apache_commons_matrix/core.clj
@@ -189,4 +189,19 @@
   RealVector
   (distance [a b] (.getDistance a (mp/coerce-param a b))))
 
+(extend-protocol mp/PDoubleArrayOutput
+  RealVector
+  (to-double-array [m] (.toArray m))
+  (as-double-array [m] nil)
+  ArrayRealVector
+  (to-double-array [m] (.getDataRef m))
+  (as-double-array [m] (.getDataRef m))
+
+  RealMatrix
+  (to-double-array [m] (.getData m))
+  (as-double-array [m] nil)
+  Array2DRowRealMatrix
+  (to-double-array [m] (.getDataRef m))
+  (as-double-array [m] (.getDataRef m)))
+
 (imp/register-implementation (Array2DRowRealMatrix. 1 1))


### PR DESCRIPTION
Implementations included for both abstract and concrete types since other implementations are all on the abstract types, but more efficient versions are available for the concrete types.
